### PR TITLE
jemalloc: use 64KiB pages for linux on aarch64

### DIFF
--- a/contrib/libs/jemalloc/include/jemalloc/internal/jemalloc_internal_defs-linux-aarch64.h
+++ b/contrib/libs/jemalloc/include/jemalloc/internal/jemalloc_internal_defs-linux-aarch64.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "jemalloc_internal_defs-linux.h"
+
+#undef LG_PAGE
+#undef LG_HUGEPAGE
+
+// 64 KiB page size is compatible with 4, 16, 64 KiB
+#define LG_PAGE 16
+
+// 2 MiB huge pages are available in all modes
+#define LG_HUGEPAGE 21

--- a/contrib/libs/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/contrib/libs/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -8,6 +8,8 @@
 #   include "jemalloc_internal_defs-win.h"
 #elif defined(__linux__) && defined(__arm__)
 #   include "jemalloc_internal_defs-linux-arm.h"
+#elif defined(__linux__) && defined(__aarch64__)
+#   include "jemalloc_internal_defs-linux-aarch64.h"
 #else
 #   include "jemalloc_internal_defs-linux.h"
 #endif


### PR DESCRIPTION
Kernel supports page sizes: 4, 16, 64 KiB.
Huge pages 2 MiB are supported in all cases.

For common usage 64 KiB and 2 MiB are compatible with any mode
with little extra cost. This is default in facebook jemalloc.

Link: https://github.com/jemalloc/jemalloc/issues/2639
Link: https://github.com/facebook/jemalloc/pull/34
Link: https://www.kernel.org/doc/html/next/arm64/memory.html
Link: https://docs.kernel.org/arch/arm64/hugetlbpage.html
Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
