### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/contrib/tools/m4/lib/vasnprintf.c
+++ b/contrib/tools/m4/lib/vasnprintf.c
@@ -849,7 +849,9 @@ convert_to_decimal (mpn_t a, size_t extra_zeroes)
   size_t a_len = a.nlimbs;
   /* 0.03345 is slightly larger than log(2)/(9*log(10)).  */
   size_t c_len = 9 * ((size_t)(a_len * (GMP_LIMB_BITS * 0.03345f)) + 1);
-  char *c_ptr = (char *) malloc (xsum (c_len, extra_zeroes));
+  /* We need extra_zeroes bytes for zeroes, followed by c_len bytes for the
+     digits of a, followed by 1 byte for the terminating NUL.  */
+  char *c_ptr = (char *) malloc (xsum (xsum (extra_zeroes, c_len), 1));
   if (c_ptr != NULL)
     {
       char *d_ptr = c_ptr;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in convert_to_decimal that was cloned from https://github.com/coreutils/gnulib but did not receive the security patch.

### Details:
Affected Function: convert_to_decimal in contrib/tools/m4/lib/vasnprintf.c
Original Fix: https://github.com/coreutils/gnulib/commit/278b4175c9d7dd47c1a3071554aac02add3b3c35

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/coreutils/gnulib/commit/278b4175c9d7dd47c1a3071554aac02add3b3c35
- https://nvd.nist.gov/vuln/detail/CVE-2018-17942

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
